### PR TITLE
fix: change regex to detect valid tweet entry id

### DIFF
--- a/lib/plugins/twitter.js
+++ b/lib/plugins/twitter.js
@@ -31,7 +31,7 @@ function extractTweetId(href) {
   // Extract '690077988243836928' from https://twitter.com/nodenpm/status/690077988243836928?ref_src=twsrc
   var pathname = _url2.default.parse(href).pathname || '';
   var tweetId = _path2.default.basename(pathname);
-  var isValidTweetId = /\d+/.test(tweetId);
+  var isValidTweetId = /^\d+$/.test(tweetId);
   return isValidTweetId ? tweetId : null;
 }
 

--- a/src/plugins/twitter.js
+++ b/src/plugins/twitter.js
@@ -5,7 +5,7 @@ function extractTweetId(href) {
   // Extract '690077988243836928' from https://twitter.com/nodenpm/status/690077988243836928?ref_src=twsrc
   const pathname = url.parse(href).pathname || '';
   const tweetId = path.basename(pathname);
-  const isValidTweetId = /\d+/.test(tweetId);
+  const isValidTweetId = /^\d+$/.test(tweetId);
   return isValidTweetId ? tweetId : null;
 }
 

--- a/tests/plugins/twitter-test.js
+++ b/tests/plugins/twitter-test.js
@@ -18,6 +18,14 @@ describe('twitter', () => {
     expect(result).to.equal(fixture);
   });
 
+  it('does not change tag when the link is not entry.', () => {
+    const html = '<a href="https://twitter.com/nodenpm12345">Twitter</a>';
+    const fixture = '<a href="https://twitter.com/nodenpm12345">Twitter</a>';
+    const builder = ampBuilder(html);
+    const result = builder.toAmpTwitter().html();
+    expect(result).to.equal(fixture);
+  });
+
   it('changes tag when the twitter embed.', () => {
     const html = '<blockquote class="twitter-tweet" lang="en"><p lang="en" dir="ltr">bentojs-api-email (1.0.0): <a href="https://t.co/kujT9n6i2P">https://t.co/kujT9n6i2P</a> A module written for the bentojs api platform for emails</p>&mdash; npm tweets (@nodenpm) <a href="https://twitter.com/nodenpm/status/690077988243836928">January 21, 2016</a></blockquote><script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>';
     const fixture = '<amp-twitter width="486" height="657" data-tweetid="690077988243836928" data-cards="visible" layout="responsive"></amp-twitter>';


### PR DESCRIPTION
Tweet idのチェックは「数字のみ」に変更しました。
